### PR TITLE
feat: introduce eXo parent pom - EXO-64103

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <artifactId>maven-parent-exo-pom</artifactId>
+    <artifactId>maven-exo-parent-pom</artifactId>
     <groupId>org.exoplatform</groupId>
     <version>26-SNAPSHOT</version>
     <relativePath />
@@ -11,7 +11,7 @@
   <artifactId>commons-exo</artifactId>
   <version>6.5.x-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>eXo PLF:: Commons</name>
+  <name>eXo PLF:: Commons eXo Platform</name>
   <modules>
   </modules>
   <scm>
@@ -24,17 +24,28 @@
     <!-- **************************************** -->
     <!-- Project Dependencies                     -->
     <!-- **************************************** -->
-    <org.exoplatform.gatein.portal.version>6.5.x-exo-SNAPSHOT</org.exoplatform.gatein.portal.version>
-  
+    <org.exoplatform.maven-exo-depmgt-pom.version>22.x-SNAPSHOT</org.exoplatform.maven-exo-depmgt-pom.version>
+
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>
   </properties>
-  
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.exoplatform</groupId>
+        <artifactId>maven-exo-depmgt-pom</artifactId>
+        <version>${org.exoplatform.maven-exo-depmgt-pom.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
-    
+
   </build>
-  
-  <!-- This profile is used to allow github action to build branches. The github action is used for sonar analysis --> 
+
+  <!-- This profile is used to allow github action to build branches. The github action is used for sonar analysis -->
   <profiles>
     <profile>
       <id>project-repositories</id>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>commons-exo</artifactId>
   <version>6.5.x-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>eXo PLF:: Commons eXo Platform</name>
+  <name>eXo PLF:: eXo Platform Commons</name>
   <modules>
   </modules>
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>maven-exo-parent-pom</artifactId>
     <groupId>org.exoplatform</groupId>
-    <version>26-SNAPSHOT</version>
+    <version>26-M01</version>
     <relativePath />
   </parent>
   <groupId>org.exoplatform.commons-exo</groupId>


### PR DESCRIPTION
This feature introduce new parent pom for eXo to be able to declare libraries versions used only in eXo, without impacting meeds