### PR TITLE
feat : Move deprecated juzu dependencies from meeds-io to exo - EXO-66190 - meeds-io/MIPs#79

### DIFF
--- a/commons-juzu/pom.xml
+++ b/commons-juzu/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.exoplatform.commons-exo</groupId>
+    <artifactId>commons-exo</artifactId>
+    <version>6.5.x-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>commons-juzu</artifactId>
+  <packaging>jar</packaging>
+  <name>eXo PLF:: Commons - Juzu Bridge for Platform</name>
+  <description>
+    This module contains :
+    - assemblies for Juzu application packaging inside eXoPlatform
+    - eXo Kernel Provider Factory
+  </description>
+  <dependencies>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-common</artifactId>
+    </dependency>
+
+    <!-- Juzu -->
+    <dependency>
+      <groupId>org.juzu</groupId>
+      <artifactId>juzu-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.juzu</groupId>
+      <artifactId>juzu-plugins-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.juzu</groupId>
+      <artifactId>juzu-plugins-less</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.juzu</groupId>
+      <artifactId>juzu-plugins-less4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.juzu</groupId>
+      <artifactId>juzu-plugins-webjars</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.juzu</groupId>
+      <artifactId>juzu-plugins-portlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.juzu</groupId>
+      <artifactId>juzu-plugins-upload</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/commons-juzu/src/main/java/org/exoplatform/commons/juzu/KernelProviderFactory.java
+++ b/commons-juzu/src/main/java/org/exoplatform/commons/juzu/KernelProviderFactory.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2012 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.exoplatform.commons.juzu;
+
+import juzu.inject.ProviderFactory;
+import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.spi.ComponentAdapter;
+
+import javax.inject.Provider;
+
+/**
+ * Provides kernel services in Juzu application.
+ *
+ * @author <a href="mailto:frederic.drouet@exoplatform.com">Frederic Drouet</a>
+ */
+public class KernelProviderFactory implements ProviderFactory {
+
+    @Override
+    public <T> Provider<? extends T> getProvider(final Class<T> implementationType) throws Exception {
+        final PortalContainer container = PortalContainer.getInstance();
+        if (container == null) {
+            throw new IllegalStateException("Not running in the context of a portal container");
+        }
+        final ComponentAdapter adapter = container.getComponentAdapterOfType(implementationType);
+        if (adapter != null) {
+            return new Provider<T>() {
+                @Override
+                public T get() {
+                    Object service = adapter.getComponentInstance();
+                    if (service == null) {
+                        throw new RuntimeException("Could not obtain service " + implementationType + " from container " + container);
+                    }
+                    return implementationType.cast(service);
+                }
+            };
+        } else {
+            return null;
+        }
+    }
+}

--- a/commons-juzu/src/main/java/org/exoplatform/commons/juzu/ajax/Ajax.java
+++ b/commons-juzu/src/main/java/org/exoplatform/commons/juzu/ajax/Ajax.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2012 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.exoplatform.commons.juzu.ajax;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Ajax {
+}

--- a/commons-juzu/src/main/java/org/exoplatform/commons/juzu/ajax/AjaxMetaModelPlugin.java
+++ b/commons-juzu/src/main/java/org/exoplatform/commons/juzu/ajax/AjaxMetaModelPlugin.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2012 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.exoplatform.commons.juzu.ajax;
+
+import juzu.impl.common.Name;
+import juzu.impl.plugin.application.metamodel.ApplicationMetaModel;
+import juzu.impl.plugin.application.metamodel.ApplicationMetaModelPlugin;
+import juzu.impl.metamodel.AnnotationKey;
+import juzu.impl.metamodel.AnnotationState;
+import juzu.impl.compiler.ElementHandle;
+import juzu.impl.common.JSON;
+import juzu.impl.compiler.ProcessingContext;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Set;
+
+/** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
+public class AjaxMetaModelPlugin extends ApplicationMetaModelPlugin {
+
+  /** . */
+  private static final Name AJAX = Name.create(Ajax.class);
+
+  /** . */
+  private final HashMap<ElementHandle.Package, Boolean> enabledMap = new HashMap<ElementHandle.Package, Boolean>();
+
+  public AjaxMetaModelPlugin() {
+    super("plf4-ajax");
+  }
+
+  @Override
+  public Set<Class<? extends java.lang.annotation.Annotation>> init(ProcessingContext env) {
+    return Collections.<Class<? extends java.lang.annotation.Annotation>>singleton(Ajax.class);
+  }
+
+  @Override
+  public void processAnnotationAdded(ApplicationMetaModel metaModel, AnnotationKey key, AnnotationState added) {
+    if (key.getType().equals(AJAX)) {
+      ElementHandle.Package handle = metaModel.getHandle();
+      enabledMap.put(handle, true);
+    }
+  }
+
+  @Override
+  public void processAnnotationRemoved(ApplicationMetaModel metaModel, AnnotationKey key, AnnotationState removed) {
+    if (key.getType().equals(AJAX)) {
+      ElementHandle.Package handle = metaModel.getHandle();
+      enabledMap.remove(handle);
+    }
+  }
+
+  @Override
+  public void init(ApplicationMetaModel application) {
+  }
+
+  @Override
+  public void destroy(ApplicationMetaModel application) {
+    enabledMap.remove(application.getHandle());
+  }
+
+  @Override
+  public JSON getDescriptor(ApplicationMetaModel application) {
+    ElementHandle.Package handle = application.getHandle();
+    Boolean enabled = enabledMap.get(handle);
+    return enabled != null && enabled ? new JSON() : null;
+  }
+}

--- a/commons-juzu/src/main/java/org/exoplatform/commons/juzu/ajax/AjaxService.java
+++ b/commons-juzu/src/main/java/org/exoplatform/commons/juzu/ajax/AjaxService.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2012 eXo Platform SAS.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.exoplatform.commons.juzu.ajax;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import juzu.Response;
+import juzu.impl.plugin.ServiceContext;
+import juzu.impl.plugin.ServiceDescriptor;
+import juzu.impl.plugin.application.ApplicationService;
+import juzu.impl.plugin.controller.ControllerService;
+import juzu.impl.request.ControllerHandler;
+import juzu.impl.request.Request;
+import juzu.impl.request.RequestFilter;
+import juzu.impl.request.Stage;
+import juzu.io.Chunk;
+import juzu.io.Stream;
+import juzu.io.Streamable;
+import juzu.request.Phase;
+
+/** @author <a href="mailto:julien.viet@exoplatform.com">Julien Viet</a> */
+public class AjaxService extends ApplicationService implements RequestFilter<Stage.Unmarshalling> {
+
+  /** . */
+  Map<String, ControllerHandler> table;
+
+  @Inject
+  ControllerService controllerService;
+
+  public AjaxService() {
+    super("plf4-ajax");
+  }
+
+  @Override
+  public ServiceDescriptor init(ServiceContext context) throws Exception {
+    return context.getConfig() != null ? new ServiceDescriptor() : null;
+  }
+
+  @PostConstruct
+  public void start() throws Exception {
+    //
+    Map<String, ControllerHandler> table = new HashMap<String, ControllerHandler>();
+    for (ControllerHandler cm : controllerService.getDescriptor().getHandlers()) {
+      Ajax ajax = cm.getMethod().getAnnotation(Ajax.class);
+      if (ajax != null) {
+        table.put(cm.getName(), cm);
+      }
+    }
+
+    //
+    this.table = table;
+  }
+
+  @Override
+  public Class<Stage.Unmarshalling> getStageType() {
+    return Stage.Unmarshalling.class;
+  }
+
+  @Override
+  public Response handle(Stage.Unmarshalling argument) {
+    final Request request = argument.getRequest();
+    Response result = argument.invoke();
+
+    //
+    if (request.getPhase() == Phase.VIEW) {
+      if (result instanceof Response.Content) {
+        Response.Status status = (Response.Status)result;
+        final Streamable wrapped = status.streamable();
+        Streamable wrapper = new Streamable() {
+          public void send(final Stream stream) throws IllegalStateException {
+            Stream our = new Stream() {
+              boolean done = false;
+              public void provide(Chunk chunk) {
+                if (chunk instanceof Chunk.Data && !done) {
+                  done = true;
+                  // FOR NOW WE DO WITH THE METHOD NAME
+                  // BUT THAT SHOULD BE REVISED TO USE THE ID INSTEAD
+                  StringBuilder sb = new StringBuilder();
+                  sb.append("<div class=\"jz\">\n");
+                  for (Map.Entry<String, ControllerHandler> entry : table.entrySet()) {
+                    String baseURL = request.createDispatch(entry.getValue()).toString();
+                    sb.append("<div data-method-id=\"");
+                    sb.append(entry.getValue().getId());
+                    sb.append("\" data-url=\"");
+                    sb.append(baseURL);
+                    sb.append("\"></div>");
+                  }
+                  stream.provide(Chunk.create(sb));
+                }
+                stream.provide(chunk);
+              }
+              public void close(Thread.UncaughtExceptionHandler errorHandler) {
+                stream.provide(Chunk.create("</div>"));
+                stream.close(errorHandler);
+              }
+            };
+            wrapped.send(our);
+          }
+        };
+        result = new Response.Content(status.getCode(), wrapper);
+      }
+    }
+
+    //
+    return result;
+  }
+}

--- a/commons-juzu/src/main/resources/META-INF/services/juzu.impl.plugin.application.ApplicationService
+++ b/commons-juzu/src/main/resources/META-INF/services/juzu.impl.plugin.application.ApplicationService
@@ -1,0 +1,1 @@
+org.exoplatform.commons.juzu.ajax.AjaxService

--- a/commons-juzu/src/main/resources/META-INF/services/juzu.impl.plugin.application.metamodel.ApplicationMetaModelPlugin
+++ b/commons-juzu/src/main/resources/META-INF/services/juzu.impl.plugin.application.metamodel.ApplicationMetaModelPlugin
@@ -1,0 +1,1 @@
+org.exoplatform.commons.juzu.ajax.AjaxMetaModelPlugin

--- a/commons-juzu/src/main/resources/META-INF/services/juzu.inject.ProviderFactory
+++ b/commons-juzu/src/main/resources/META-INF/services/juzu.inject.ProviderFactory
@@ -1,0 +1,1 @@
+org.exoplatform.commons.juzu.KernelProviderFactory

--- a/commons-juzu/src/main/resources/assemblies/platform-juzu.xml
+++ b/commons-juzu/src/main/resources/assemblies/platform-juzu.xml
@@ -1,0 +1,48 @@
+<!--
+  ~ Copyright (C) 2011 eXo Platform SAS.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<assembly xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd"
+          xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <id>platform-juzu</id>
+  <formats>
+    <format>war</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.outputDirectory}</directory>
+      <outputDirectory>/WEB-INF/classes</outputDirectory>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.sourceDirectory}</directory>
+      <outputDirectory>/WEB-INF/src</outputDirectory>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/src/main/webapp</directory>
+      <outputDirectory>/</outputDirectory>
+      <excludes>
+	     <exclude>**/less/**</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/${project.build.finalName}/skin/css</directory>
+      <outputDirectory>/skin/css</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
   <packaging>pom</packaging>
   <name>eXo PLF:: eXo Platform Commons</name>
   <modules>
+    <module>commons-juzu</module>
     <module>web</module>
   </modules>
   <scm>
@@ -40,6 +41,11 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+      <groupId>org.exoplatform.commons-exo</groupId>
+      <artifactId>commons-juzu</artifactId>
+      <version>${project.version}</version>
+    </dependency>
       <dependency>
         <groupId>org.exoplatform.commons-exo</groupId>
         <artifactId>commons-exo.portal.web.eXoSkin</artifactId>


### PR DESCRIPTION
Juzu dependency is deprecated in meeds.
We still need it for chat, rh-management and customer space. We move it in eXo side waiting the refactor of these components.