### PR TITLE
fix: Fix add the file_drop module to exo commons resources - EXO-68825

### DIFF
--- a/web/eXoResources/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/web/eXoResources/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -992,7 +992,7 @@
     </depends>
   </module>
   <module>
-    <name>filedrop</name>
+    <name>file_drop</name>
     <script>
       <path>/javascript/lib/jquery.filedrop.js</path>
     </script>


### PR DESCRIPTION
Prior to this change, after moving the filedrop module from the commons to the perk-store addon, by uninstalling the perk-store addon from the exo server, we were not able to add an illustration to the news or drop a file on the chat application. This change is going to add the file_drop module to exo commons resources  resources to resolve this issue.
