### PR TITLE
fix: Toast notification are not correctly displayed - EXO-69838

### DIFF
--- a/web/eXoSkin/src/main/webapp/skin/less/customStyle.less
+++ b/web/eXoSkin/src/main/webapp/skin/less/customStyle.less
@@ -14,34 +14,3 @@ You should have received a copy of the GNU Lesser General Public License
 along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 */
-//put your custom style here
-
-.VuetifyApp {
-  .v-application {
-    .v-alert:not(.position-static):not(.position-relative) {
-      position: fixed;
-      z-index: 1000;
-      bottom: 15px;
-      left: 35px;
-      box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 1px 5px 0px rgba(0, 0, 0, 0.12) !important;
-      border-left: 5px solid;
-    }
-
-    .v-alert__content{
-      padding-right: 50px ~'; /** orientation=lt */ ';
-      padding-left: 50px ~'; /** orientation=rt */ ';
-    }
-
-    .v-alert__icon.v-icon {
-      margin-top: auto;
-      margin-bottom: auto;
-    }
-  }
-  @media (max-width: 371px) {
-    .v-snack__wrapper {
-      min-width:100%;
-
-    }
-  }
-}
-


### PR DESCRIPTION
Before this fix, toast notification have an exo-custom style, which render it different from meeds default style. This commit remove the custom styling to use the default one