### PR TITLE
fix: fix displaying kudos number selector - EXO-69894

### DIFF
--- a/web/eXoSkin/src/main/webapp/skin/less/platform/skin/enterprise.less
+++ b/web/eXoSkin/src/main/webapp/skin/less/platform/skin/enterprise.less
@@ -752,7 +752,6 @@ option:checked:hover {
 }
 
 input,
-select,
 .uneditable-input {
   width: 270px;
 }


### PR DESCRIPTION
Before this change, the select tag took width:270px, which makes the select box too wide. cause a bad display for the kudos number in the kudos admin form drawer After this change, the select tag takes the default one 220px, and the kudos number selector is well displayed