### PR TITLE
feat: Allow to use WebUI portlets in new layout manager - MEED-5649 -Meeds-io/MIPs#120

### DIFF
--- a/web/eXoResources/src/main/webapp/javascript/eXo/core/Base.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/core/Base.js
@@ -24,26 +24,42 @@
    * This is the main entry method for every Ajax calls to the eXo Portal
    * 
    * It is simply a dispatcher method that fills some init fields before calling
-   * the doRequest() method
+   * the window.doRequest() method
    */
   window.ajaxGet = function(url, callback) {
     if (!callback)
       callback = null;
-    require([ "SHARED/portalRequest" ], function() {
-      doRequest("Get", url, null, callback);
+   window.require([ "SHARED/portalRequest" ], function() {
+      if (window.eXo.env.portal.maximizedPortletMode) {
+        if (url.includes('?')) {
+          url += '&';
+        } else {
+          url += '?';
+        }
+        url += `maximizedPortletMode=${window.eXo.env.portal.maximizedPortletMode}`;
+      }
+      window.doRequest("Get", url, null, callback);
     });
   };
   
   /**
    * Do a POST request in AJAX with given <code>url</code> and
-   * <code>queryString</code>. The call is delegated to the doRequest() method
+   * <code>queryString</code>. The call is delegated to the window.doRequest() method
    * with a callback function
    */
   window.ajaxPost = function(url, queryString, callback) {
     if (!callback)
       callback = null;
-    require([ "SHARED/portalRequest" ], function() {
-      doRequest("POST", url, queryString, callback);
+   window.require([ "SHARED/portalRequest" ], function() {
+      if (window.eXo.env.portal.maximizedPortletMode) {
+        if (url.includes('?')) {
+          url += '&';
+        } else {
+          url += '?';
+        }
+        url += `maximizedPortletMode=${window.eXo.env.portal.maximizedPortletMode}`;
+      }
+      window.doRequest("POST", url, queryString, callback);
     });
   };
   

--- a/web/eXoResources/src/main/webapp/javascript/eXo/portal/PortalHttpRequest.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/portal/PortalHttpRequest.js
@@ -564,7 +564,13 @@
         return;
       var parentBlock = null;
       if (parentId && parentId != "") {
-        parentBlock = $("#" + parentId);
+        const selector = window.eXo.env.portal.maximizedPortletMode ?
+          `#${parentId}[data-mode='${window.eXo.env.portal.maximizedPortletMode}']`
+          : `#${parentId}`;
+        parentBlock = $(selector);
+        if (!parentBlock.length && window.eXo.env.portal.maximizedPortletMode) {
+          parentBlock = $(`#${parentId}`);
+        }
 
         // Workaround: In the case of the Portlet is being rendered/displayed in
         // Edit Layout mode
@@ -660,10 +666,11 @@
                  * any finer block to update. Hence replace the innerHTML inside
                  * the id="PORTLET-FRAGMENT" block
                  */
-                var parentBlock = $("#" + portletResponse.portletId);
-                var target = $(
-                    "#" + portletResponse.portletId + " .PORTLET-FRAGMENT")
-                    .first();
+                const portletSelector = window.eXo.env.portal.maximizedPortletMode ?
+                  `#${portletResponse.portletId}[data-mode='${window.eXo.env.portal.maximizedPortletMode}']`
+                  : `#${portletResponse.portletId}`;
+                var parentBlock = $(portletSelector);
+                var target = $(`${portletSelector} .PORTLET-FRAGMENT`).first();
                 target.html(portletResponse.portletData);
 
                 // update embedded scripts
@@ -678,8 +685,7 @@
                 /*
                  * Else updates each block with the portlet
                  */
-                instance.updateBlocks(portletResponse.blocksToUpdate,
-                    portletResponse.portletId);
+                instance.updateBlocks(portletResponse.blocksToUpdate, portletResponse.portletId);
               }
             });
       }

--- a/web/eXoResources/src/main/webapp/javascript/eXo/webui/UIForm.js
+++ b/web/eXoResources/src/main/webapp/javascript/eXo/webui/UIForm.js
@@ -73,7 +73,7 @@
 	    }
 	    else
 	    {
-	      return $("#" + ids[0]).find("#" + ids[1])[0];
+	      return $("#" + ids[0]).find("#" + ids[1])[0] || $("#UIPortlet-" + ids[0]).find("#" + ids[1])[0];
 	    }
 	  },
 	


### PR DESCRIPTION
This change will fix the usage of `require` method to make it **non** contextual by prefixing it using `window.`. In addition , this will enhance the WebUI Ajax queries update to allow updating the editing portlet instead of the displayed portlet when both are present in the same page.
( Resolves Meeds-io/MIPs#120 )