### PR TITLE
feat: Add note editor plugins extensions - EXO-73170 - Meeds-io/MIPs#128

### DIFF
--- a/commons-exo-extension/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/commons-exo-extension/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -30,4 +30,15 @@
       <module>eXoVueI18n</module>
     </depends>
   </module>
+  <module>
+    <name>WYSIWYGPluginsExtensions</name>
+    <load-group>NotesEditorGRP</load-group>
+    <script>
+      <minify>false</minify>
+      <path>/js/WYSIWYGPluginsExtensions.bundle.js</path>
+    </script>
+    <depends>
+      <module>extensionRegistry</module>
+    </depends>
+  </module>
 </gatein-resources>

--- a/commons-exo-extension/src/main/webapp/vue-app/noteEditorPluginsExtensions/extensions.js
+++ b/commons-exo-extension/src/main/webapp/vue-app/noteEditorPluginsExtensions/extensions.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2024 eXo Platform SAS
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <gnu.org/licenses>.
+ */
+
+export function init() {
+  if (eXo.ecm) {
+    CKEDITOR.plugins.addExternal('uploadImage', '/eXoWCMResources/eXoPlugins/uploadImage/', 'plugin.js');
+    CKEDITOR.plugins.addExternal('selectImage', '/eXoWCMResources/eXoPlugins/selectImage/', 'plugin.js');
+
+    extensionRegistry.registerExtension('WYSIWYGPlugins', 'image', {
+      id: 'selectImage',
+      extraPlugin: 'selectImage',
+      extraToolbarItem: 'selectImage',
+      rank: 20,
+    });
+  }
+}

--- a/commons-exo-extension/webpack.prod.js
+++ b/commons-exo-extension/webpack.prod.js
@@ -23,6 +23,7 @@ const config = {
   },
   entry: {
     eXoPlatformGamificationConnectorExtensions: './src/main/webapp/vue-app/gamification-connectorExtensions/extensions.js',
+    WYSIWYGPluginsExtensions: './src/main/webapp/vue-app/noteEditorPluginsExtensions/extensions.js'
   },
   output: {
     path: path.join(__dirname, 'target/commons-exo-extension/'),


### PR DESCRIPTION
Prior to this change, after removing the attachment app from the content module, the "select image" option was not available because the WYSIWYG plugins were registered in the attachment app. This change will add the Note Editor WYSIWYG Plugins Extension, which will be included using the load group in the content module, resolving this issue!