### PR TITLE
fix : space layout for spaces created in 6.3 and before is broken - EXO-77650

### DIFF
--- a/web/eXoSkin/src/main/webapp/skin/less/social/skin/social.less
+++ b/web/eXoSkin/src/main/webapp/skin/less/social/skin/social.less
@@ -51,7 +51,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 /* this css is needed for spaces created in 6.3 and before.
 It allow to display them correctly in 7.0.0 */
 
-#ApplicationChildren {
+#ApplicationChildren:has(td.SpaceHomeActivitiesTDContainer) {
 	display:flex;
   .SpaceHomeActivitiesTDContainer {
     flex-grow: 0;


### PR DESCRIPTION
Before this fix, spaces created in 6.3 and before are broken in 7.0.0 This commit update the css to prevent being applied on other page than activity stream