### PR TITLE
fix: Fix Wallet.transaction cache name - MEED-9615 - Meeds-io/meeds#3598

### DIFF
--- a/commons-exo-extension/src/main/webapp/WEB-INF/conf/commons-exo/cache-configuration.xml
+++ b/commons-exo-extension/src/main/webapp/WEB-INF/conf/commons-exo/cache-configuration.xml
@@ -114,7 +114,7 @@
       <type>org.exoplatform.services.cache.ExoCacheConfigPlugin</type>
       <description>Configures the cache for analytics queue which must remain a local cache</description>
       <init-params>
-        <object-param>
+        <object-param profiles="analytics">
           <name>analytics.queue</name>
           <description></description>
           <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
@@ -259,7 +259,7 @@
             </field>
           </object>
         </object-param>
-        <object-param>
+        <object-param profiles="gamification">
           <name>gamification.domain</name>
           <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
             <field name="name">
@@ -273,7 +273,7 @@
             </field>
           </object>
         </object-param>
-        <object-param>
+        <object-param profiles="gamification">
           <name>gamification.rule</name>
           <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
             <field name="name">
@@ -287,7 +287,7 @@
             </field>
           </object>
         </object-param>
-        <object-param>
+        <object-param profiles="gamification">
           <name>gamification.realization</name>
           <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
             <field name="name">
@@ -301,7 +301,7 @@
             </field>
           </object>
         </object-param>
-        <object-param>
+        <object-param profiles="notes">
           <name>wiki.PageRenderingCache</name>
           <description>The wiki markup cache configuration</description>
           <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
@@ -326,7 +326,7 @@
             </field>
           </object>
         </object-param>
-        <object-param>
+        <object-param profiles="notes">
           <name>wiki.PageAttachmentCache</name>
           <description>The Cache configuration for wiki page attachment count</description>
           <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
@@ -351,7 +351,7 @@
             </field>
           </object>
         </object-param>
-        <object-param>
+        <object-param profiles="perkstore">
           <name>perkstore.product</name>
           <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
             <field name="name">
@@ -365,7 +365,7 @@
             </field>
           </object>
         </object-param>
-        <object-param>
+        <object-param profiles="perkstore">
           <name>perkstore.order</name>
           <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
             <field name="name">
@@ -1383,32 +1383,32 @@
             </field>
           </object>
         </object-param>
-        <object-param>
-          <name>wallet.transactions</name>
+        <object-param profiles="wallet">
+          <name>wallet.transaction</name>
           <description>Wallet application transactions cache</description>
           <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
             <field name="name">
-              <string>wallet.transactions</string>
+              <string>wallet.transaction</string>
             </field>
             <field name="maxSize">
-              <int>${exo.cache.wallet.transactions.MaxNodes:2000}</int>
+              <int>${exo.cache.wallet.transaction.MaxNodes:2000}</int>
             </field>
             <field name="liveTime">
-              <long>${exo.cache.wallet.transactions.TimeToLive:-1}</long>
+              <long>${exo.cache.wallet.transaction.TimeToLive:-1}</long>
             </field>
             <field
               name="strategy"
               profiles="cluster">
-              <string>${exo.cache.wallet.transactions.strategy:LIRS}</string>
+              <string>${exo.cache.wallet.transaction.strategy:LIRS}</string>
             </field>
             <field
               name="cacheMode"
               profiles="cluster">
-              <string>${exo.cache.wallet.transactions.cacheMode:asyncInvalidation}</string>
+              <string>${exo.cache.wallet.transaction.cacheMode:asyncInvalidation}</string>
             </field>
           </object>
         </object-param>
-        <object-param>
+        <object-param profiles="wallet">
           <name>wallet.account</name>
           <description></description>
           <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
@@ -1436,7 +1436,7 @@
         <object-param>
           <name>social.profileSettings</name>
           <description></description>
-          <object type="org.exoplatform.services.cache.ExoCacheConfig">
+          <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
             <field name="name">
               <string>social.profileSettings</string>
             </field>
@@ -1446,12 +1446,22 @@
             <field name="liveTime">
               <long>${exo.cache.social.profileSettings.TimeToLive:-1}</long>
             </field>
+            <field
+              name="strategy"
+              profiles="cluster">
+              <string>${exo.cache.social.profileSettings.strategy:LIRS}</string>
+            </field>
+            <field
+              name="cacheMode"
+              profiles="cluster">
+              <string>${exo.cache.social.profileSettings.cacheMode:asyncInvalidation}</string>
+            </field>
           </object>
         </object-param>
         <object-param>
           <name>social.profileSettingIdsByName</name>
           <description></description>
-          <object type="org.exoplatform.services.cache.ExoCacheConfig">
+          <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
             <field name="name">
               <string>social.profileSettingIdsByName</string>
             </field>
@@ -1460,6 +1470,41 @@
             </field>
             <field name="liveTime">
               <long>${exo.cache.social.profileSettingIdsByName.TimeToLive:-1}</long>
+            </field>
+            <field
+              name="strategy"
+              profiles="cluster">
+              <string>${exo.cache.social.profileSettingIdsByName.strategy:LIRS}</string>
+            </field>
+            <field
+              name="cacheMode"
+              profiles="cluster">
+              <string>${exo.cache.social.profileSettingIdsByName.cacheMode:asyncInvalidation}</string>
+            </field>
+          </object>
+        </object-param>
+        <object-param profiles="ide">
+          <name>ide.widget</name>
+          <description></description>
+          <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
+            <field name="name">
+              <string>ide.widget</string>
+            </field>
+            <field name="maxSize">
+              <int>${exo.cache.ide.widget.MaxNodes:2000}</int>
+            </field>
+            <field name="liveTime">
+              <long>${exo.cache.ide.widget.TimeToLive:-1}</long>
+            </field>
+            <field
+              name="strategy"
+              profiles="cluster">
+              <string>${exo.cache.ide.widget.strategy:LIRS}</string>
+            </field>
+            <field
+              name="cacheMode"
+              profiles="cluster">
+              <string>${exo.cache.ide.widget.cacheMode:asyncInvalidation}</string>
             </field>
           </object>
         </object-param>


### PR DESCRIPTION
Prior to this change, the Cache name 'wallet.transaction' was configured with a different name ('s' added at the end). This fixes the Cache Name.
In addition, this change will introduce the new cache configuration for 'ide.widget'

Resolves Meeds-io/meeds#3598